### PR TITLE
Adding support for $or directives

### DIFF
--- a/lib/embedded-mongo/backend/collection.rb
+++ b/lib/embedded-mongo/backend/collection.rb
@@ -171,7 +171,11 @@ module EmbeddedMongo::Backend
       EmbeddedMongo.log.debug("partial_match? #{partial_selector.inspect} #{value.inspect}")
       case partial_selector
       when Array, Numeric, String, BSON::ObjectId, TrueClass, FalseClass, Time, nil
-        partial_selector == value
+        if value.kind_of? Array then
+          value.include? partial_selector
+        else
+          partial_selector == value
+        end
       when Hash
         if no_directive?(partial_selector)
           partial_selector == value

--- a/lib/embedded-mongo/backend/collection.rb
+++ b/lib/embedded-mongo/backend/collection.rb
@@ -160,6 +160,10 @@ module EmbeddedMongo::Backend
           v.any? do |partial_selector| 
             selector_match?(partial_selector, doc)
           end
+        elsif(k == "$and")
+          v.all? do |partial_selector|
+            selector_match?(partial_selector, doc)
+          end
         else
           partial_match?(v, doc[k]) 
         end

--- a/test/functional/interface_test.rb
+++ b/test/functional/interface_test.rb
@@ -37,7 +37,7 @@ class InterfaceTest < Test::Unit::TestCase
       selector,
       {'$set'=>{'baz'=>'bingo'}},
       :upsert => true
-    )
+      )
     cursor = @foo_collection.find(selector)
     assert_equal 1, cursor.count
     entry = cursor.first
@@ -48,12 +48,12 @@ class InterfaceTest < Test::Unit::TestCase
     selector = {'fubar'=>'rubar'}
     @foo_collection.insert(
       selector.merge('tweedle'=>'dee')
-    )
+      )
     @foo_collection.update(
       selector,
       {'$set'=>{'baz'=>'bingo'}},
       :upsert => true
-    )
+      )
     cursor = @foo_collection.find(selector)
     assert_equal 1, cursor.count
     entry = cursor.first
@@ -65,11 +65,11 @@ class InterfaceTest < Test::Unit::TestCase
     selector = {'fubar'=>'rubar'}
     @foo_collection.insert(
       selector.merge('baz'=>1)
-    )
+      )
     @foo_collection.update(
       selector,
       {'$inc'=>{'baz'=>2}}
-    )
+      )
     cursor = @foo_collection.find(selector)
     assert_equal 1, cursor.count
     entry = cursor.first
@@ -80,13 +80,13 @@ class InterfaceTest < Test::Unit::TestCase
     selector = {'fubar'=>'rubar'}
     @foo_collection.insert(
       selector.merge('baz'=>'not an integer')
-    )
+      )
 
     assert_raise(Mongo::OperationFailure) do
       @foo_collection.update(
         selector,
         {'$inc'=>{'baz'=>2}}
-      )
+        )
     end
   end
 
@@ -95,7 +95,7 @@ class InterfaceTest < Test::Unit::TestCase
       {'foo' => 'bart','_id'=>0xdeadbeef},
       {'$set'=>{'baz'=>'bingo'}},
       :upsert => true
-    )
+      )
     cursor = @foo_collection.find({ 'foo' => 'bart' })
     assert_equal 1, cursor.count
     entry = cursor.first
@@ -154,6 +154,16 @@ class InterfaceTest < Test::Unit::TestCase
     p res1
   end
 
+  def test_and_support
+    @foo_collection.insert({ 'e' => 10 })
+    @foo_collection.insert({ 'e' => 20 })
+    @foo_collection.insert({ 'e' => 30 })
+
+    cursor1 = @foo_collection.find({:$or=>[{'e'=>10}, {'e'=>20}], :$and=>[{'e'=>10}]})
+    res1 = cursor1.to_a
+    assert_equal(1, res1.length)
+  end
+
   def test_for_in
     @foo_collection.insert({'q'=>['der', 'dor']})
     @foo_collection.insert({'q'=>['dar', 'dot']})
@@ -164,4 +174,5 @@ class InterfaceTest < Test::Unit::TestCase
     res1 = cursor1.to_a
     assert_equal(2, res1.length)
   end
+
 end

--- a/test/functional/interface_test.rb
+++ b/test/functional/interface_test.rb
@@ -153,4 +153,15 @@ class InterfaceTest < Test::Unit::TestCase
     assert_equal(2, res1.length)
     p res1
   end
+
+  def test_for_in
+    @foo_collection.insert({'q'=>['der', 'dor']})
+    @foo_collection.insert({'q'=>['dar', 'dot']})
+    @foo_collection.insert({'q'=>['dot']})
+
+
+    cursor1 = @foo_collection.find({'q'=>'dot'})
+    res1 = cursor1.to_a
+    assert_equal(2, res1.length)
+  end
 end

--- a/test/functional/interface_test.rb
+++ b/test/functional/interface_test.rb
@@ -142,4 +142,15 @@ class InterfaceTest < Test::Unit::TestCase
     assert_equal(10, res2[1]['a'])
     assert_equal(nil, res2[2]['a'])
   end
+
+  def test_or_support
+    @foo_collection.insert({ 'e' => 10 })
+    @foo_collection.insert({ 'e' => 20 })
+    @foo_collection.insert({ 'e' => 30 })
+
+    cursor1 = @foo_collection.find(:$or=>[{'e'=>10}, {'e'=>20}])
+    res1 = cursor1.to_a
+    assert_equal(2, res1.length)
+    p res1
+  end
 end


### PR DESCRIPTION
I noticed that I didn't get passing tests when using embedded-mongo with a $or directive.
So I added support to it.

Here is a passing test along with $or check in the selector_match? method of the backend.

I also added support for looking for values inside an array, so it should match how mongo searches for values. Again here, there is a supporting test attached.
